### PR TITLE
Fix bug in networkx1.11 + graphviz on OS X

### DIFF
--- a/disagree.py
+++ b/disagree.py
@@ -196,7 +196,7 @@ def monolingual_main(args):
         if (args.verbose):
           print("  annotator %s score: %d" % (test_anno, score))
 
-        ag = nx.to_agraph(g)
+        ag = nx.drawing.nx_agraph.to_agraph(g)
         ag.graph_attr['label'] = sent
         ag.layout(prog=args.layout)
         ag.draw('%s/%s_annotated_%s_%s.png' % (args.outdir, cur_id, gold_anno, test_anno))
@@ -250,7 +250,7 @@ def xlang_main(args):
     if (args.verbose):
       print("ID: %s\n Sentence: %s\n Sentence: %s\n Score: %f" % (cur_id, src_sent, tgt_sent, amr_graphs[0][1]))
 
-    ag = nx.to_agraph(amr_graphs[0][0])
+    ag = nx.drawing.nx_agraph.to_agraph(amr_graphs[0][0])
     ag.graph_attr['label'] = "%s\n%s" % (src_sent, tgt_sent)
     ag.layout(prog=args.layout)
     ag.draw('%s/%s.png' % (args.outdir, cur_id))


### PR DESCRIPTION
When run with a simple AMR input, I get:
Traceback (most recent call last):
  File "./disagree.py", line 317, in <module>
    monolingual_main(args)
  File "./disagree.py", line 199, in monolingual_main
    ag = nx.to_agraph(g)
AttributeError: 'module' object has no attribute 'to_agraph'

This seems to be caused by a bug "in the `draw_graphviz` function in
networkx-1.11 triggered by the change that the graphviz drawing tools
are no longer imported into the top level namespace of networkx"

See: http://stackoverflow.com/a/35280794/800207

This commit fixese the issue by replacing direct `nx.to_agraph()` call
with appropriate full path calls.

I tried reproducing the error on Ubuntu but did not succeed.
I am creating this PR in case somebody else faces similar issue.
